### PR TITLE
feature: update composer.json to support 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "rss": "https://github.com/acalvino4/craft-easy-image/releases.atom"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.1|>=8.2",
         "craftcms/cms": "^4.4.0",
         "dodecastudio/craft-blurhash": "^2.0"
     },


### PR DESCRIPTION
As can be seen in  https://github.com/acalvino4/craft-easy-image/blob/master/.ddev/config.yaml#L4
the PHP version used in testing & linting is already 8.2.
Since the entire testing pipeline runs without issue that means 8.2 should officially be supported as well.

This should fix the following
![image](https://github.com/acalvino4/craft-easy-image/assets/76262772/2db9b00a-ea41-4d44-b75e-422c6ce913b6)